### PR TITLE
feat: new 'position' option 'Replace [toc] Placeholder'

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -1077,6 +1077,11 @@ if ( ! class_exists( 'ezTOC' ) ) {
 							$content    = self::mb_find_replace( $find, $replace, $content );
 							break;
 
+						case 'placeholder':
+							$content = self::mb_find_replace( $find, $replace, $content );
+							$content = preg_replace( '/\[toc.*\]/i', $html, $content );
+							break;
+
 						case 'before':
 						default:
 							$replace[0] = $html . $replace[0];

--- a/includes/class.options.php
+++ b/includes/class.options.php
@@ -185,6 +185,7 @@ if ( ! class_exists( 'ezTOC_Option' ) ) {
 								'after' => __( 'After first heading', 'ez_toc' ),
 								'top' => __( 'Top', 'ez_toc' ),
 								'bottom' => __( 'Bottom', 'ez_toc' ),
+								'placeholder' => __( 'Replace [toc] Placeholder', 'ez_toc' ),
 							),
 							'default' => 1,
 						),


### PR DESCRIPTION
For backwards compatibility with content that uses the `[toc]` shortcode
from the old "Table of Content Plus" plugin, an new 'position' option is
introduced.

If that option is selected on the plugin admin page, the TOC is inserted
at the place where the old `[toc]` shortcode is found. This also works
for shortcodes with optional arguments, e. g. `[toc exclude="foo*"]`.

This pull request provides a workaround for issue #14.