### PR TITLE
Prettier Indentation of TOC Items Containing Line Breaks

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -145,21 +145,37 @@
 	counter-reset: item;
 }
 
+#ez-toc-container.counter-hierarchy ul li,
+.ez-toc-widget-container.counter-hierarchy ul li {
+	display: table;
+}
+
+#ez-toc-container.counter-hierarchy ul li::before,
+.ez-toc-widget-container.counter-hierarchy ul li::before {
+	display: table-cell;
+	padding-right: 0.6em;
+}
+
+#ez-toc-container.counter-hierarchy ul li ul,
+.ez-toc-widget-container.counter-hierarchy ul li ul {
+	margin-left: 0;
+}
+
 #ez-toc-container.counter-numeric li,
 .ez-toc-widget-container.counter-numeric li {
 	list-style-type: decimal;
 	list-style-position: inside;
 }
 
-#ez-toc-container.counter-decimal ul.ez-toc-list li a::before,
-.ez-toc-widget-container.counter-decimal ul.ez-toc-list li a::before {
-	content: counters(item, ".") ". ";
+#ez-toc-container.counter-decimal ul.ez-toc-list li::before,
+.ez-toc-widget-container.counter-decimal ul.ez-toc-list li::before {
+	content: counters(item, ".");
 	counter-increment: item;
 }
 
-#ez-toc-container.counter-roman li a::before,
-.ez-toc-widget-container.counter-roman ul.ez-toc-list li a::before {
-	content: counters(item, ".", upper-roman) ". ";
+#ez-toc-container.counter-roman li::before,
+.ez-toc-widget-container.counter-roman ul.ez-toc-list li::before {
+	content: counters(item, ".", upper-roman);
 	counter-increment: item;
 }
 


### PR DESCRIPTION
Before:
![eztoc_before](https://user-images.githubusercontent.com/148286/37006523-140d4272-20d9-11e8-8ac7-331cc6dd9114.png)

After:
![eztoc_after](https://user-images.githubusercontent.com/148286/37006527-165a6622-20d9-11e8-9006-4a7ac8d490f4.png)

As a side effect the numbers are no longer linked. I also set them a little further apart and removed the last dot. I think it looks cleaner that way. Just a suggestion.

PS: Your screen.min.css looks like it needs updating even without merging this PR.