### PR TITLE
fixed a warning in admin

### DIFF
--- a/includes/class.admin.php
+++ b/includes/class.admin.php
@@ -337,7 +337,7 @@ if ( ! class_exists( 'ezTOC_Admin' ) ) {
 		 */
 		public function save( $post_id, $post, $update ) {
 
-			if ( current_user_can( 'edit_post', $post_id ) && wp_verify_nonce( $_REQUEST['_ez_toc_nonce'], 'ez_toc_save' ) ) {
+			if ( current_user_can( 'edit_post', $post_id ) && isset( $_REQUEST['_ez_toc_nonce'] ) && wp_verify_nonce( $_REQUEST['_ez_toc_nonce'], 'ez_toc_save' ) ) {
 
 				// Checkboxes are present if checked, absent if not.
 				if ( isset( $_REQUEST['ez-toc-settings']['disabled-toc'] ) ) {


### PR DESCRIPTION
I think I used the admin bar -> new -> page, and for some reason the nonce field was not set, but save() was being called on the edit screen, producing a warning. This PR fixed the warning.