### PR TITLE
Change [toc] Shortcode via filter and add TOC always if shortcode is used

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -933,7 +933,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 		 *
 		 * @return array
 		 */
-		public static function build( $content ) {
+		public static function build( $content, $is_shortcode = false ) {
 
 			$css_classes = '';
 
@@ -944,7 +944,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 
 			if ( $items ) {
 
-				if ( self::is_eligible() ) {
+				if ( $is_shortcode || self::is_eligible() ) {
 
 					// wrapping css classes
 					switch ( ezTOC_Option::get( 'wrapping' ) ) {
@@ -1102,7 +1102,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 			if ( $run ) {
 
 				$id   = get_the_ID();
-				$args = self::build( get_the_content( $id ) );
+				$args = self::build( get_the_content( $id ), true );
 				$out  = $args['content'];
 				$run  = FALSE;
 			}

--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -34,6 +34,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 if ( ! class_exists( 'ezTOC' ) ) {
 
+	// Start Easy Table of Contents.
+	add_action( 'init', array( 'ezTOC', 'instance' ) );
+
 	/**
 	 * Class ezTOC
 	 */
@@ -68,6 +71,16 @@ if ( ! class_exists( 'ezTOC' ) ) {
 		 * @var array
 		 */
 		private static $collision_collector = array();
+
+		/**
+		 * Name of the Shortcode to show toc.
+		 *
+		 * Should only be modified through the filter hook 'eztoc_shortcode'.
+		 *
+		 * @since 1.7.0
+		 * @var string
+		 */
+		public static $shortcode = 'toc';
 
 		/**
 		 * A dummy constructor to prevent the class from being loaded more than once.
@@ -142,13 +155,15 @@ if ( ! class_exists( 'ezTOC' ) ) {
 		 */
 		private static function hooks() {
 
+			self::$shortcode = apply_filters( 'eztoc_shortcode', self::$shortcode );
+
 			add_action( 'plugins_loaded', array( __CLASS__, 'loadTextdomain' ) );
 			add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueueScripts' ) );
 
 			// Run after shortcodes are interpreted (priority 10).
 			add_filter( 'the_content', array( __CLASS__, 'the_content' ), 100 );
 			add_shortcode( 'ez-toc', array( __CLASS__, 'shortcode' ) );
-			add_shortcode( 'toc', array( __CLASS__, 'shortcode' ) );
+			add_shortcode( self::$shortcode, array( __CLASS__, 'shortcode' ) );
 		}
 
 		/**
@@ -1173,9 +1188,6 @@ if ( ! class_exists( 'ezTOC' ) ) {
 
 		return ezTOC::instance();
 	}
-
-	// Start Easy Table of Contents.
-	ezTOC();
 }
 
 


### PR DESCRIPTION
# New Feature 1: Added the possibility to change the [toc] shortcode via apply_filters

The user can change the [toc] shortcode with a filter. For example add the following into your theme functions.php or your plugin:

```
add_filter('eztoc_shortcode', 'eztoc_change_toc_shortcode');
/**
 * Change the EZ TOC Shortcode from [toc] to something else.
 *
 * @param string $shortcode Current EZ TOC [toc] Shortcode.
 * @return string New EZ TOC Shortcode.
 */
public function eztoc_change_toc_shortcode($shortcode)  {
   return 'index';
}
```

Afterwards you can use [index] as shortcode instead of [toc]. This is important if you are using the [toc] shortcode already for something else.

# New Feature 2: Present TOC always if user adds the shortcode

If the shortcode [toc] (can be modified with filter - see first commit) or [ez-toc] is used in the post, then the TOC will be presented always - even if the user not activated the TOC in the metabox or not used auto insert