### PR TITLE
Do not run on nested excluded filters

### DIFF
--- a/easy-table-of-contents.php
+++ b/easy-table-of-contents.php
@@ -517,7 +517,7 @@ if ( ! class_exists( 'ezTOC' ) ) {
 			global $wp_current_filter;
 
 			// Do not execute if root current filter is one of those in the array.
-			if ( in_array( $wp_current_filter[0], array( 'get_the_excerpt', 'init', 'wp_head' ), true ) ) {
+			if ( ! empty( array_intersect( $wp_current_filter, array( 'get_the_excerpt', 'init', 'wp_head' ) ) ) ) {
 
 				$apply = false;
 			}


### PR DESCRIPTION
The plugin is currently running for post excerpts, which is causing severe performance issues when displaying a grid of post excerpts on a page (a ToC is generated for each of the excerpts even though it's ultimately not used). `maybeApplyTheContentFilter` is intended to prevent this from happening, but there are several scenarios where `get_the_excerpt` is not the top most filter. For example, we're using beaver builder's post grid and the plugin is executed with the following filter stack:
```php
Array
(
    [0] => genesis_loop
    [1] => genesis_entry_content
    [2] => the_content
    [3] => get_the_excerpt
    [4] => the_content
)
```

This PR addresses that issue an skips ToC generation for all descendants of `get_the_excerpt` (and other reserved filters), not just immediate children.