### PR TITLE
Add `ez-toc-container` class to container

### DIFF
--- a/includes/class.post.php
+++ b/includes/class.post.php
@@ -1090,7 +1090,7 @@ class ezTOC_Post {
 	 */
 	public function getTOC() {
 
-		$class = array( 'ez-toc-v' . str_replace( '.', '_', ezTOC::VERSION ) );
+		$class = array( 'ez-toc-container ez-toc-v' . str_replace( '.', '_', ezTOC::VERSION ) );
 		$html  = '';
 
 		if ( $this->hasTOCItems() ) {


### PR DESCRIPTION
Currently, the container does not include a base HTML class.
So if you want to apply styles to all ToC elements regardless of their configuration, you either have to use the `#ez-toc-container` id (which some might consider bad practice) or use an unnecessarily inconvenient attribute selector (`[class^="ez-toc-"]`). Of course, you could use the `ez_toc_container_class` filter to add the class yourself, but you'd need to do this on every project you use the plugin in.

By adding a generic `.ez-toc-container` class, none of the "workarounds" would be necessary.