### PR TITLE
Prevent default action when clicking an ez-toc-link item

### DIFF
--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -50,8 +50,10 @@ jQuery( function( $ ) {
 
 		if ( 1 === smoothScroll ) {
 
-			$( 'a.ez-toc-link' ).on( 'click', function() {
+			$( 'a.ez-toc-link' ).on( 'click', function(e) {
 
+				e.preventDefault();
+				
 				var self = $( this );
 
 				var target = '';


### PR DESCRIPTION
This helps to avoid page jump or 'jerk' when clicking items in some circumstances. Sites that I have used this plugin on have seen this issue. Adding this fixes it.