### PR TITLE
Remove the str_replace for smart quotes, as it was causing issues wit…

### DIFF
--- a/includes/inc.cord-functions.php
+++ b/includes/inc.cord-functions.php
@@ -307,8 +307,6 @@ function mb_find_replace( &$find = false, &$replace = false, &$string = '' ) {
 						);
 					}
 
-					$needle = str_replace(array('’','“','”'), array('\'','"','"'), $needle);
-
                     $start = mb_strpos( $string, $needle );
 				}
 


### PR DESCRIPTION
…h matching content, and shouldn't be necessary anymore.

See the relevant issue:

https://github.com/ahmedkaludi/easy-table-of-contents/issues/902

Please note that I only very rarely contribute to open source/third party projects. If there's anything I should do differently with this PR (I looked for contribution guidelines but couldn't find any) then please let me know.